### PR TITLE
BVERSION-217: In publication configuration, improve the source picker

### DIFF
--- a/application-book-versions-ui/src/main/resources/BookVersions/Code/PublicationConfigurationClass.xml
+++ b/application-book-versions-ui/src/main/resources/BookVersions/Code/PublicationConfigurationClass.xml
@@ -236,7 +236,6 @@
           ## target top level documents (e.g. create a top level document, move a document to the top level, etc.).
           #set ($showRoot = !$showWikis)
           #set ($showTerminalDocuments = false || $options.showTerminalDocuments)
-          #set ($showSpaces = false || $options.showSpaces)
           #documentTree({
             'class': 'location-tree',
             'finder': true,
@@ -246,8 +245,7 @@
             'showTranslations': false,
             'showWikis': $showWikis,
             'exclusions': "$!options.exclusions",
-            'root': "$!options.root",
-            'showSpaces': $showSpaces
+            'root': "$!options.root"
           })
         &lt;/div&gt;
         &lt;div class="modal-footer"&gt;
@@ -293,7 +291,7 @@
         'reference': $currentValue,
         'placeholder': 'core.create.spaceReference.placeholder'
       },
-      "root": "space:$services.model.serialize($rootParentRef, 'default')",
+      "root": "document:${services.model.serialize($rootParentRef, 'default')}.WebHome",
       'showSpaces': true
     })
 #else


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/BVERSION-217

# Changes

## Description

Following [this discussion](https://github.com/xwiki/xwiki-platform/pull/3874#discussion_r2063489250) it seem that the source picker in the publication configuration page is not completely correctly configured. Currently it was wrongly configured to use the old depreciated hierarchy.

Following [this discussion](https://matrix.to/#/!ikPtGZaGWtyblizzlR:matrix.xwiki.com/$1745912443139elsOk:matrix.xwiki.com?via=matrix.org&via=matrix.xwiki.com&via=uni-wuppertal.de) I found the correct configuration to make the picker working correctly with the new XWiki hierarchy.

# Screenshots & Video

![image](https://github.com/user-attachments/assets/89efe2e0-5dce-42b2-bd27-51b8eb70c5dc)

# Executed Tests

Just tested that the picker list the child pages.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: No